### PR TITLE
feat(auth): refactoring login/register interface with fixed tab

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^19.0.0",
         "react-bootstrap": "^2.10.9",
         "react-dom": "^19.0.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.2",
         "sass": "^1.87.0"
       },
@@ -2886,6 +2887,15 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^19.0.0",
     "react-bootstrap": "^2.10.9",
     "react-dom": "^19.0.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.2",
     "sass": "^1.87.0"
   },

--- a/src/index.css
+++ b/src/index.css
@@ -67,3 +67,22 @@ button:focus-visible {
     background-color: #f9f9f9;
   }
 }
+.custom-tabs .nav-link {
+  color: #555;
+  font-weight: 500;
+  border: none;
+  border-bottom: 2px solid transparent;
+  transition: all 0.3s ease;
+  padding-bottom: 8px;
+}
+
+.custom-tabs .nav-link.active {
+  color: #d70018; /* màu đỏ đậm */
+  font-weight: 600;
+  border-bottom: 2px solid #d70018;
+  background-color: transparent;
+}
+
+.custom-tabs .nav-item {
+  margin-right: 16px;
+}

--- a/src/pages/User/Authentication/LoginRegisterForm.css
+++ b/src/pages/User/Authentication/LoginRegisterForm.css
@@ -1,0 +1,19 @@
+.custom-tabs .nav-link {
+  color: #555;
+  font-weight: 500;
+  border: none;
+  border-bottom: 2px solid transparent;
+  transition: all 0.3s ease;
+  padding-bottom: 8px;
+}
+
+.custom-tabs .nav-link.active {
+  color: #d70018 !important; /* màu đỏ đậm */
+  font-weight: 600;
+  border-bottom: 2px solid #d70018;
+  background-color: transparent !important;
+}
+
+.custom-tabs .nav-item {
+  margin-right: 16px;
+}

--- a/src/pages/User/Authentication/LoginRegisterForm.jsx
+++ b/src/pages/User/Authentication/LoginRegisterForm.jsx
@@ -1,0 +1,145 @@
+import { useState } from "react";
+import {
+  Form,
+  Button,
+  Tabs,
+  Tab,
+  InputGroup,
+  FormControl,
+} from "react-bootstrap";
+import { FaGoogle, FaFacebookF } from "react-icons/fa";
+import "./LoginRegisterForm.css";
+
+function LoginForm() {
+  const [key, setKey] = useState("login");
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div className="d-flex justify-content-center align-items-center min-vh-100 bg-light">
+      <div
+        className="p-4 rounded shadow bg-white"
+        style={{ width: "500px", minHeight: "600px" }}
+      >
+        <Tabs
+          activeKey={key}
+          onSelect={(k) => setKey(k)}
+          className="custom-tabs mb-4"
+          justify
+        >
+          <Tab eventKey="login" title="Đăng nhập">
+            <Form>
+              <Form.Group className="mb-3" controlId="formPhoneOrEmail">
+                <Form.Label>Số điện thoại/Email</Form.Label>
+                <Form.Control type="text" placeholder="Nhập..." />
+              </Form.Group>
+
+              <Form.Group className="mb-2" controlId="formPassword">
+                <Form.Label>Mật khẩu</Form.Label>
+                <InputGroup>
+                  <FormControl
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Nhập mật khẩu"
+                  />
+                  <Button
+                    variant="outline-secondary"
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    size="sm"
+                  >
+                    {showPassword ? "Ẩn" : "Hiện"}
+                  </Button>
+                </InputGroup>
+              </Form.Group>
+
+              <div className="d-flex justify-content-end mb-3">
+                <a
+                  href="/forgot-password"
+                  className="text-danger text-decoration-none"
+                  style={{ fontSize: "0.9rem" }}
+                >
+                  Quên mật khẩu?
+                </a>
+              </div>
+
+              <Button
+                variant="danger"
+                type="submit"
+                className="w-100 rounded-pill mb-3"
+              >
+                Đăng nhập
+              </Button>
+
+              <div className="text-center mb-2 text-muted">hoặc</div>
+
+              <Button
+                variant="outline-dark"
+                className="w-100 mb-2 d-flex align-items-center justify-content-center gap-2"
+              >
+                <FaGoogle /> Đăng nhập bằng Google
+              </Button>
+
+              <Button
+                variant="primary"
+                className="w-100 d-flex align-items-center justify-content-center gap-2"
+              >
+                <FaFacebookF /> Đăng nhập bằng Facebook
+              </Button>
+            </Form>
+          </Tab>
+
+          <Tab eventKey="register" title="Đăng ký">
+            <Form>
+              <Form.Group className="mb-3" controlId="formPhoneOrEmail">
+                <Form.Label>Số điện thoại/Email</Form.Label>
+                <Form.Control type="text" placeholder="Nhập..." />
+              </Form.Group>
+
+              <Form.Group className="mb-2" controlId="formPassword">
+                <Form.Label>Mật khẩu</Form.Label>
+                <InputGroup>
+                  <FormControl
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Nhập mật khẩu"
+                  />
+                  <Button
+                    variant="outline-secondary"
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    size="sm"
+                  >
+                    {showPassword ? "Ẩn" : "Hiện"}
+                  </Button>
+                </InputGroup>
+              </Form.Group>
+
+              <Form.Group className="mb-3" controlId="formConfirmPassword">
+                <Form.Label>Xác nhận mật khẩu</Form.Label>
+                <InputGroup>
+                  <FormControl
+                    type={showPassword ? "text" : "password"}
+                    placeholder="Nhập lại mật khẩu"
+                  />
+                  <Button
+                    variant="outline-secondary"
+                    onClick={() => setShowPassword((prev) => !prev)}
+                    size="sm"
+                  >
+                    {showPassword ? "Ẩn" : "Hiện"}
+                  </Button>
+                </InputGroup>
+              </Form.Group>
+
+              <Button
+                variant="danger"
+                type="submit"
+                className="w-100  rounded-pill mb-3 "
+              >
+                Đăng ký
+              </Button>
+            </Form>
+          </Tab>
+        </Tabs>
+      </div>
+    </div>
+  );
+}
+
+export default LoginForm;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -1,7 +1,7 @@
 import { Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Cart from "./pages/Cart";
-
+import LoginRegisterForm from "./pages/User/Authentication/LoginRegisterForm";
 /* // Import các page mới
 import Login from "./pages/auth/Login";
 import Register from "./pages/auth/Register";
@@ -35,9 +35,7 @@ function Router() {
       <Route path="/checkout" element={<CheckoutPage />} /> */}
 
       {/* Auth Routes */}
-      {/*       <Route path="/login" element={<Login />} />
-      <Route path="/register" element={<Register />} />
-      <Route path="/forgot-password" element={<ForgotPassword />} /> */}
+      <Route path="/login" element={<LoginRegisterForm />} />
 
       {/* User Routes */}
       {/*      <Route path="/user/profile" element={<ProfilePage />} />


### PR DESCRIPTION
- Add "Login" and "Register" tabs using react-bootstrap Tabs
- Clearly separate two forms in each tab, keep the layout fixed when switching tabs
- Add the function to show/hide password with the "Show/Hide" button
- Integrate login buttons with Google and Facebook
- Apply custom CSS to the tab interface to synchronize with brand colors
- add  package react-icons