### PR TITLE
feat: create interface and logic for password recovery page

### DIFF
--- a/src/pages/User/Authentication/LoginRegisterForm.jsx
+++ b/src/pages/User/Authentication/LoginRegisterForm.jsx
@@ -13,6 +13,48 @@ import "./LoginRegisterForm.css";
 function LoginForm() {
   const [key, setKey] = useState("login");
   const [showPassword, setShowPassword] = useState(false);
+  const [loginData, setLoginData] = useState({ email: "", password: "" });
+  const [registerData, setRegisterData] = useState({
+    email: "",
+    password: "",
+    confirmPassword: "",
+  });
+  const [errors, setErrors] = useState({});
+
+  const handleLoginSubmit = (e) => {
+    e.preventDefault();
+    const newErrors = {};
+    if (!loginData.email.trim())
+      newErrors.loginEmail = "Vui lòng nhập email hoặc số điện thoại.";
+    if (!loginData.password)
+      newErrors.loginPassword = "Vui lòng nhập mật khẩu.";
+
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
+      // Submit logic here
+      console.log("Đăng nhập:", loginData);
+    }
+  };
+
+  const handleRegisterSubmit = (e) => {
+    e.preventDefault();
+    const newErrors = {};
+    if (!registerData.email.trim())
+      newErrors.registerEmail = "Vui lòng nhập email hoặc số điện thoại.";
+    if (!registerData.password)
+      newErrors.registerPassword = "Vui lòng nhập mật khẩu.";
+    if (!registerData.confirmPassword) {
+      newErrors.confirmPassword = "Vui lòng xác nhận mật khẩu.";
+    } else if (registerData.password !== registerData.confirmPassword) {
+      newErrors.confirmPassword = "Mật khẩu không khớp.";
+    }
+
+    setErrors(newErrors);
+    if (Object.keys(newErrors).length === 0) {
+      // Submit logic here
+      console.log("Đăng ký:", registerData);
+    }
+  };
 
   return (
     <div className="d-flex justify-content-center align-items-center min-vh-100 bg-light">
@@ -27,18 +69,34 @@ function LoginForm() {
           justify
         >
           <Tab eventKey="login" title="Đăng nhập">
-            <Form>
+            <Form onSubmit={handleLoginSubmit}>
               <Form.Group className="mb-3" controlId="formPhoneOrEmail">
                 <Form.Label>Số điện thoại/Email</Form.Label>
-                <Form.Control type="text" placeholder="Nhập..." />
+                <Form.Control
+                  type="text"
+                  placeholder="Nhập..."
+                  value={loginData.email}
+                  onChange={(e) =>
+                    setLoginData({ ...loginData, email: e.target.value })
+                  }
+                  isInvalid={!!errors.loginEmail}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {errors.loginEmail}
+                </Form.Control.Feedback>
               </Form.Group>
 
               <Form.Group className="mb-2" controlId="formPassword">
                 <Form.Label>Mật khẩu</Form.Label>
-                <InputGroup>
+                <InputGroup hasValidation>
                   <FormControl
                     type={showPassword ? "text" : "password"}
                     placeholder="Nhập mật khẩu"
+                    value={loginData.password}
+                    onChange={(e) =>
+                      setLoginData({ ...loginData, password: e.target.value })
+                    }
+                    isInvalid={!!errors.loginPassword}
                   />
                   <Button
                     variant="outline-secondary"
@@ -47,6 +105,9 @@ function LoginForm() {
                   >
                     {showPassword ? "Ẩn" : "Hiện"}
                   </Button>
+                  <Form.Control.Feedback type="invalid">
+                    {errors.loginPassword}
+                  </Form.Control.Feedback>
                 </InputGroup>
               </Form.Group>
 
@@ -87,18 +148,37 @@ function LoginForm() {
           </Tab>
 
           <Tab eventKey="register" title="Đăng ký">
-            <Form>
+            <Form onSubmit={handleRegisterSubmit}>
               <Form.Group className="mb-3" controlId="formPhoneOrEmail">
                 <Form.Label>Số điện thoại/Email</Form.Label>
-                <Form.Control type="text" placeholder="Nhập..." />
+                <Form.Control
+                  type="text"
+                  placeholder="Nhập..."
+                  value={registerData.email}
+                  onChange={(e) =>
+                    setRegisterData({ ...registerData, email: e.target.value })
+                  }
+                  isInvalid={!!errors.registerEmail}
+                />
+                <Form.Control.Feedback type="invalid">
+                  {errors.registerEmail}
+                </Form.Control.Feedback>
               </Form.Group>
 
               <Form.Group className="mb-2" controlId="formPassword">
                 <Form.Label>Mật khẩu</Form.Label>
-                <InputGroup>
+                <InputGroup hasValidation>
                   <FormControl
                     type={showPassword ? "text" : "password"}
                     placeholder="Nhập mật khẩu"
+                    value={registerData.password}
+                    onChange={(e) =>
+                      setRegisterData({
+                        ...registerData,
+                        password: e.target.value,
+                      })
+                    }
+                    isInvalid={!!errors.registerPassword}
                   />
                   <Button
                     variant="outline-secondary"
@@ -107,15 +187,26 @@ function LoginForm() {
                   >
                     {showPassword ? "Ẩn" : "Hiện"}
                   </Button>
+                  <Form.Control.Feedback type="invalid">
+                    {errors.registerPassword}
+                  </Form.Control.Feedback>
                 </InputGroup>
               </Form.Group>
 
               <Form.Group className="mb-3" controlId="formConfirmPassword">
                 <Form.Label>Xác nhận mật khẩu</Form.Label>
-                <InputGroup>
+                <InputGroup hasValidation>
                   <FormControl
                     type={showPassword ? "text" : "password"}
                     placeholder="Nhập lại mật khẩu"
+                    value={registerData.confirmPassword}
+                    onChange={(e) =>
+                      setRegisterData({
+                        ...registerData,
+                        confirmPassword: e.target.value,
+                      })
+                    }
+                    isInvalid={!!errors.confirmPassword}
                   />
                   <Button
                     variant="outline-secondary"
@@ -124,13 +215,16 @@ function LoginForm() {
                   >
                     {showPassword ? "Ẩn" : "Hiện"}
                   </Button>
+                  <Form.Control.Feedback type="invalid">
+                    {errors.confirmPassword}
+                  </Form.Control.Feedback>
                 </InputGroup>
               </Form.Group>
 
               <Button
                 variant="danger"
                 type="submit"
-                className="w-100  rounded-pill mb-3 "
+                className="w-100 rounded-pill mb-3"
               >
                 Đăng ký
               </Button>

--- a/src/pages/User/ForgotPassword/ForgotPassword.jsx
+++ b/src/pages/User/ForgotPassword/ForgotPassword.jsx
@@ -1,0 +1,100 @@
+import React, { useState } from "react";
+import { Container, Form, Button, InputGroup } from "react-bootstrap";
+import { Link } from "react-router-dom";
+
+const ForgotPassword = () => {
+  const [showPassword, setShowPassword] = useState(false);
+  const [formData, setFormData] = useState({
+    email: "",
+    otp: "",
+    password: "",
+  });
+  const [errors, setErrors] = useState({});
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    const newErrors = {};
+    if (!formData.email) newErrors.email = "Không được để trống";
+    if (!formData.otp) newErrors.otp = "Không được để trống";
+    if (!formData.password) newErrors.password = "Không được để trống";
+    setErrors(newErrors);
+
+    if (Object.keys(newErrors).length === 0) {
+      // xử lý gửi form
+    }
+  };
+
+  return (
+    <Container className="mt-5" style={{ maxWidth: "500px" }}>
+      <h4 className="text-center fw-bold mb-4">KHÔI PHỤC MẬT KHẨU</h4>
+
+      <Form onSubmit={handleSubmit}>
+        <Form.Group className="mb-3">
+          <Form.Label>Số điện thoại/Email</Form.Label>
+          <Form.Control
+            type="text"
+            placeholder="Nhập số điện thoại hoặc email"
+            value={formData.email}
+            onChange={(e) =>
+              setFormData({ ...formData, email: e.target.value })
+            }
+            isInvalid={!!errors.email}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.email}
+          </Form.Control.Feedback>
+        </Form.Group>
+
+        <Form.Group className="mb-3">
+          <Form.Label>Mã xác nhận OTP</Form.Label>
+          <Form.Control
+            type="text"
+            placeholder="6 ký tự"
+            maxLength={6}
+            value={formData.otp}
+            onChange={(e) => setFormData({ ...formData, otp: e.target.value })}
+            isInvalid={!!errors.otp}
+          />
+          <Form.Control.Feedback type="invalid">
+            {errors.otp}
+          </Form.Control.Feedback>
+        </Form.Group>
+
+        <Form.Group className="mb-4">
+          <Form.Label>Mật khẩu</Form.Label>
+          <InputGroup>
+            <Form.Control
+              type={showPassword ? "text" : "password"}
+              placeholder="Nhập mật khẩu"
+              value={formData.password}
+              onChange={(e) =>
+                setFormData({ ...formData, password: e.target.value })
+              }
+              isInvalid={!!errors.password}
+            />
+            <Button
+              variant="outline-secondary"
+              onClick={() => setShowPassword(!showPassword)}
+            >
+              {showPassword ? "Ẩn" : "Hiện"}
+            </Button>
+            <Form.Control.Feedback type="invalid">
+              {errors.password}
+            </Form.Control.Feedback>
+          </InputGroup>
+        </Form.Group>
+
+        <div className="d-grid gap-2 mb-2">
+          <Button variant="danger" type="submit" className="w-100 mb-3">
+            Xác nhận
+          </Button>
+          <Button as={Link} to="/login" variant="outline-secondary">
+            Trở về
+          </Button>
+        </div>
+      </Form>
+    </Container>
+  );
+};
+
+export default ForgotPassword;

--- a/src/router.jsx
+++ b/src/router.jsx
@@ -2,10 +2,11 @@ import { Routes, Route } from "react-router-dom";
 import Home from "./pages/Home";
 import Cart from "./pages/Cart";
 import LoginRegisterForm from "./pages/User/Authentication/LoginRegisterForm";
+import ForgotPassword from "./pages/User/ForgotPassword/ForgotPassword";
+
 /* // Import các page mới
 import Login from "./pages/auth/Login";
 import Register from "./pages/auth/Register";
-import ForgotPassword from "./pages/auth/ForgotPassword";
 
 import CategoryPage from "./pages/CategoryPage";
 import ProductDetailPage from "./pages/ProductDetailPage";
@@ -36,6 +37,7 @@ function Router() {
 
       {/* Auth Routes */}
       <Route path="/login" element={<LoginRegisterForm />} />
+      <Route path="/forgot-password" element={<ForgotPassword />} />
 
       {/* User Routes */}
       {/*      <Route path="/user/profile" element={<ProfilePage />} />


### PR DESCRIPTION
- Design interface of "Password Recovery" page including fields:
+ Phone number/Email
+ OTP confirmation code
+ New password (with show/hide password button)
- Add cases to display input data errors (validation)
- Update standard layout with Container, Form, InputGroup, Button, ToggleButton
- Create beautiful, user-friendly interface, according to the provided interface template
- Add "Back" button to navigate to login page